### PR TITLE
Add basic tests

### DIFF
--- a/Sources/KraftfulAnalytics/Core/EventSender.swift
+++ b/Sources/KraftfulAnalytics/Core/EventSender.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+// The interface for sending events
+public protocol EventSender {
+  func track(name: String) -> Void
+  func track<P: Codable>(name: String, properties: P?) -> Void
+  func identify(userId: String) -> Void
+  func identify<T: Codable>(userId: String, traits: T?) -> Void
+}

--- a/Sources/KraftfulAnalytics/Core/MockEventSender.swift
+++ b/Sources/KraftfulAnalytics/Core/MockEventSender.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension KraftfulAnalytics {
+  // A mock class used by tests to verify calls
+  public class MockEventSender: EventSender {
+    public var trackCalls: Array<MockTrackCall> = []
+    public var identifyCalls: Array<MockIdentifyCall> = []
+    
+    public func track(name: String) {
+      self.track(name: name, properties: String?.none)
+    }
+    
+    public func track<P: Codable>(name: String, properties: P?) {
+      trackCalls.append(MockTrackCall(
+        name: name,
+        properties: properties
+      ));
+    }
+    
+    public func identify(userId: String) {
+      self.identify(userId: userId, traits: String?.none)
+    }
+    
+    public func identify<T: Codable>(userId: String, traits: T?) {
+      identifyCalls.append(MockIdentifyCall(
+        userId: userId,
+        traits: traits
+      ));
+    }
+
+    public struct MockTrackCall {
+      let name: String
+      let properties: Codable
+    }
+    public struct MockIdentifyCall {
+      let userId: String
+      let traits: Codable
+    }
+  }
+}

--- a/Sources/KraftfulAnalytics/Core/SegmentEventSender.swift
+++ b/Sources/KraftfulAnalytics/Core/SegmentEventSender.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Segment
+
+extension KraftfulAnalytics {
+  // An EventSender implementation for Segment
+  public class SegmentEventSender: EventSender {
+    private var analytics: Analytics;
+
+    init(key: String) {
+      let configuration = Configuration(writeKey: key)
+        .trackApplicationLifecycleEvents(true)
+        .flushInterval(10)
+      
+      analytics = Analytics(configuration: configuration)
+    }
+
+    public func track(name: String) {
+      analytics.track(name: name)
+    }
+    
+    public func track<P: Codable>(name: String, properties: P?) {
+      analytics.track(name: name, properties: properties)
+    }
+    
+    public func identify(userId: String) {
+      analytics.identify(userId: userId)
+    }
+    
+    public func identify<T: Codable>(userId: String, traits: T?) {
+      analytics.identify(userId: userId, traits: traits)
+    }
+  }
+}

--- a/Sources/KraftfulAnalytics/KraftfulAnalytics.swift
+++ b/Sources/KraftfulAnalytics/KraftfulAnalytics.swift
@@ -1,16 +1,20 @@
 import Segment
 
 public struct KraftfulAnalytics {
-  private static var analytics: Analytics? = nil
+  private static var analytics: EventSender? = nil
 
   /**
     Initializes the KraftfulAnalytics library using the supplied write key
     */
   public static func initialize(key: String) {
-    let configuration = Configuration(writeKey: key)
-      .trackApplicationLifecycleEvents(true)
-      .flushInterval(10)
-    analytics = Analytics(configuration: configuration)
+    KraftfulAnalytics.initializeWith(sender: SegmentEventSender(key: key))
+  }
+
+  /**
+   Initializes the KraftfulAnalytics library using the supplied sender (for testing)
+   */
+  public static func initializeWith(sender: EventSender) {
+    analytics = sender
   }
 
   /**
@@ -100,12 +104,14 @@ public struct KraftfulAnalytics {
   }
 }
 
-struct TrackFeatureUseProperties: Codable {
-  let kohortTrack: Int
-  let kohortStepName: String
-  let kohortFeature: String
-}
+extension KraftfulAnalytics {
+  public struct TrackFeatureUseProperties: Codable {
+    let kohortTrack: Int
+    let kohortStepName: String
+    let kohortFeature: String
+  }
 
-struct TrackBaseProperties: Codable {
-  let kohortTrack: Int
+  public struct TrackBaseProperties: Codable {
+    let kohortTrack: Int
+  }
 }

--- a/Tests/KraftfulAnalyticsTests/KraftfulAnalyticsTests.swift
+++ b/Tests/KraftfulAnalyticsTests/KraftfulAnalyticsTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import KraftfulAnalytics
+
+final class KraftfulAnalyticsTests: XCTestCase {
+  var mockSender = KraftfulAnalytics.MockEventSender()
+
+  override func setUpWithError() throws {
+    mockSender = KraftfulAnalytics.MockEventSender()
+    KraftfulAnalytics.initializeWith(sender: mockSender)
+  }
+  
+  func testTrackSignIn() {
+    KraftfulAnalytics.trackSignInStart();
+    
+    XCTAssertEqual(mockSender.trackCalls.count, 1, "Track was not called")
+    XCTAssertEqual(mockSender.trackCalls[0].name, "Sign In Start", "Invalid event name for sign in start")
+    verifyBaseProperties(properties: mockSender.trackCalls[0].properties)
+    
+    let testUserId = "test-user-id"
+    KraftfulAnalytics.trackSignInSuccess(userId: testUserId)
+    
+    XCTAssertEqual(mockSender.identifyCalls.count, 1, "Identify was not called")
+    XCTAssertEqual(mockSender.identifyCalls[0].userId, testUserId, "Invalid userId")
+    XCTAssertEqual(mockSender.trackCalls.count, 2, "Track was not called again")
+    XCTAssertEqual(mockSender.trackCalls[1].name, "Sign In Success", "Invalid event name for sign in success")
+    verifyBaseProperties(properties: mockSender.trackCalls[1].properties)
+  }
+  
+  func testTrackConnection() {
+    KraftfulAnalytics.trackConnectionStart();
+    
+    XCTAssertEqual(mockSender.trackCalls.count, 1, "Track was not called")
+    XCTAssertEqual(mockSender.trackCalls[0].name, "Connection Start", "Invalid event name for connection start")
+    verifyBaseProperties(properties: mockSender.trackCalls[0].properties)
+    
+    KraftfulAnalytics.trackConnectionSuccess()
+    
+    XCTAssertEqual(mockSender.trackCalls.count, 2, "Track was not called again")
+    XCTAssertEqual(mockSender.trackCalls[1].name, "Connection Success", "Invalid event name for connection success")
+    verifyBaseProperties(properties: mockSender.trackCalls[1].properties)
+  }
+  
+  func testTrackFeatureUse() {
+    let testFeature = "Test Feature"
+    KraftfulAnalytics.trackFeatureUse(feature: testFeature)
+    
+    XCTAssertEqual(mockSender.trackCalls.count, 1, "Track was not called")
+    XCTAssertEqual(mockSender.trackCalls[0].name, testFeature, "Event name does not match track call")
+    verifyTrackFeatureProperties(properties: mockSender.trackCalls[0].properties, feature: testFeature)
+  }
+  
+  func testTrackAppReturn() {
+    let testUserId = "test-user-id-2"
+    KraftfulAnalytics.trackAppReturn(userId: testUserId)
+    
+    XCTAssertEqual(mockSender.identifyCalls.count, 1, "Identify was not called")
+    XCTAssertEqual(mockSender.identifyCalls[0].userId, testUserId, "Invalid userId")
+    XCTAssertEqual(mockSender.trackCalls.count, 1, "Track was not called again")
+    XCTAssertEqual(mockSender.trackCalls[0].name, "Return", "Invalid event name for return")
+    verifyBaseProperties(properties: mockSender.trackCalls[0].properties)
+  }
+  
+  func verifyBaseProperties(properties: Codable) {
+    let baseProps = properties as! KraftfulAnalytics.TrackBaseProperties
+    XCTAssertEqual(baseProps.kohortTrack, 1, "Invalid kohortTrack property")
+  }
+  
+  func verifyTrackFeatureProperties(properties: Codable, feature: String) {
+    let trackProps = properties as! KraftfulAnalytics.TrackFeatureUseProperties
+    XCTAssertEqual(trackProps.kohortTrack, 1, "Invalid kohortTrack property")
+    XCTAssertEqual(trackProps.kohortStepName, "Feature use", "Invalid kohortStepName property")
+    XCTAssertEqual(trackProps.kohortFeature, feature, "Invalid feature property; expected \(feature)")
+  }
+}


### PR DESCRIPTION
- Refactor KraftfulAnalytics to use new EventSender protocol instead of the Segment Analytics instance directly so it can be mocked
- Implement MockEventSender for testing
- Implement SegmentEventSender for actual implementation
- Add test cases for each method

Tests Report:

<img width="394" alt="Screen Shot 2022-06-22 at 3 13 20 PM" src="https://user-images.githubusercontent.com/164497/175161826-a2e4b517-9b54-44ff-bbe9-e2e5cf8db440.png">

